### PR TITLE
feat: move AddressType schema from address-validation to accounts

### DIFF
--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -271,6 +271,40 @@ type AccountEdge implements NodeEdge {
   node: Account
 }
 
+"""
+Wraps a list of `Addresses`, providing pagination cursors and information.
+
+For information about what Relay-compatible connections are and how to use them, see the following articles:
+- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
+- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
+- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
+"""
+type AddressConnection {
+  "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
+  edges: [AddressEdge]
+
+  """
+  You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+  if you know you will not need to paginate the results.
+  """
+  nodes: [Address]
+
+  "Information to help a client request the next or previous page"
+  pageInfo: PageInfo!
+
+  "The total number of nodes that match your query"
+  totalCount: Int!
+}
+
+"A connection edge in which each node is an `Address` object"
+type AddressEdge {
+  "The cursor that represents this node in the paginated results"
+  cursor: ConnectionCursor!
+
+  "The address"
+  node: Address
+}
+
 "The response from the `addAccountAddressBookEntry` mutation"
 type AddAccountAddressBookEntryPayload {
   "The added address"

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -10,6 +10,15 @@ enum AccountSortByField {
   updatedAt
 }
 
+"A list of the possible types of `Address`"
+enum AddressType {
+  "Address can be used for payment transactions and invoicing"
+  billing
+
+  "Address can be used as a mailing address for sending physical items"
+  shipping
+}
+
 "Defines a new Address and the account to which it should be added"
 input AddAccountAddressBookEntryInput {
   "The account ID"


### PR DESCRIPTION
The `AddressType` and `AddressConnection` schemas were created in the `address-validation` plugin, but only used in the `accounts` plugin.

This PR moves these schemas into this plugin, where they are used.