### PR TITLE
Add updateGroupsForAccounts mutation

### DIFF
--- a/src/mutations/index.js
+++ b/src/mutations/index.js
@@ -15,6 +15,7 @@ import setAccountDefaultEmail from "./setAccountDefaultEmail.js";
 import updateAccount from "./updateAccount.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import updateAccountGroup from "./updateAccountGroup.js";
+import updateGroupsForAccounts from "./updateGroupsForAccounts.js";
 
 export default {
   addressBookAdd,
@@ -33,5 +34,6 @@ export default {
   setAccountDefaultEmail,
   updateAccount,
   updateAccountAddressBookEntry,
-  updateAccountGroup
+  updateAccountGroup,
+  updateGroupsForAccounts
 };

--- a/src/mutations/updateGroupsForAccounts.js
+++ b/src/mutations/updateGroupsForAccounts.js
@@ -51,7 +51,7 @@ export default async function updateGroupsForAccounts(context, input) {
   }
 
   const shopIds = groupsToAssignAccountsTo.reduce((allShopIds, group) => {
-    if (!allShopIds.includes(group.shopId)) {
+    if (group.shopId && !allShopIds.includes(group.shopId)) {
       allShopIds.push(group.shopId);
     }
 

--- a/src/mutations/updateGroupsForAccounts.js
+++ b/src/mutations/updateGroupsForAccounts.js
@@ -42,7 +42,7 @@ export default async function updateGroupsForAccounts(context, input) {
     }
   }).toArray();
 
-  if (!groupsToAssignAccountsTo) {
+  if (groupsToAssignAccountsTo.length === 0) {
     throw new ReactionError("not-found", "No groups matching the provided IDs were found");
   }
 
@@ -68,7 +68,7 @@ export default async function updateGroupsForAccounts(context, input) {
     }
   }).toArray();
 
-  if (!accounts) {
+  if (accounts.length === 0) {
     throw new ReactionError("not-found", "No accounts matching the provided IDs were found");
   }
 

--- a/src/mutations/updateGroupsForAccounts.js
+++ b/src/mutations/updateGroupsForAccounts.js
@@ -50,16 +50,16 @@ export default async function updateGroupsForAccounts(context, input) {
     throw new ReactionError("not-found", `Could not find ${groupIds.length - groupsToAssignAccountsTo.length} of ${groupIds.length} groups provided`);
   }
 
-  const shopIds = groupsToAssignAccountsTo.reduce((allShopIds, group) => {
-    if (group.shopId && !allShopIds.includes(group.shopId)) {
-      allShopIds.push(group.shopId);
+  for (const group of groupsToAssignAccountsTo) {
+    let groupShopId;
+
+    if (group.shopId) {
+      groupShopId = {
+        shopId: group.shopId
+      };
     }
 
-    return allShopIds;
-  }, []);
-
-  for (let shopId of shopIds) {
-    await context.validatePermissions("reaction:legacy:groups", "manage:accounts", { shopId });
+    await context.validatePermissions("reaction:legacy:groups", "manage:accounts", groupShopId);
   }
 
   const accounts = await Accounts.find({
@@ -90,7 +90,7 @@ export default async function updateGroupsForAccounts(context, input) {
     _id: {
       $in: accountIds
     }
-  }).toArray()
+  }).toArray();
 
   for (let updatedAccount of updatedAccounts) {
     await appEvents.emit("afterAccountUpdate", {

--- a/src/mutations/updateGroupsForAccounts.js
+++ b/src/mutations/updateGroupsForAccounts.js
@@ -82,7 +82,8 @@ export default async function updateGroupsForAccounts(context, input) {
     }
   }, {
     $set: {
-      groups: groupIds
+      groups: groupIds,
+      updatedAt: new Date()
     }
   });
 

--- a/src/mutations/updateGroupsForAccounts.js
+++ b/src/mutations/updateGroupsForAccounts.js
@@ -1,0 +1,105 @@
+import ReactionError from "@reactioncommerce/reaction-error";
+import SimpleSchema from "simpl-schema";
+
+const inputSchema = new SimpleSchema({
+  accountIds: {
+    type: Array
+  },
+  "accountIds.$": String,
+  groupIds: {
+    type: Array
+  },
+  "groupIds.$": String
+});
+
+/**
+ * @name accounts/updateGroupsForAccounts
+ * @memberof Mutations/Accounts
+ * @method
+ * @summary Bulk-update group assignments for specified accounts
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Input arguments
+ * @param {String} input.accountIds - The account IDs
+ * @param {String} input.groupIds - The group IDs
+ * @return {Promise<Object>} accounts with updated groups
+ */
+export default async function updateGroupsForAccounts(context, input) {
+  inputSchema.validate(input);
+
+  const { accountIds, groupIds } = input;
+  const {
+    appEvents,
+    collections: {
+      Accounts,
+      Groups
+    },
+    userId
+  } = context;
+
+  const groupsToAssignAccountsTo = await Groups.find({
+    _id: {
+      $in: groupIds
+    }
+  }).toArray();
+
+  if (!groupsToAssignAccountsTo) {
+    throw new ReactionError("not-found", "No groups matching the provided IDs were found");
+  }
+
+  if (groupsToAssignAccountsTo.length !== groupIds.length) {
+    throw new ReactionError("not-found", `Could not find ${groupIds.length - groupsToAssignAccountsTo.length} of ${groupIds.length} groups provided`);
+  }
+
+  const shopIds = groupsToAssignAccountsTo.reduce((allShopIds, group) => {
+    if (!allShopIds.includes(group.shopId)) {
+      allShopIds.push(group.shopId);
+    }
+
+    return allShopIds;
+  }, []);
+
+  for (let shopId of shopIds) {
+    await context.validatePermissions("reaction:legacy:groups", "manage:accounts", { shopId });
+  }
+
+  const accounts = await Accounts.find({
+    _id: {
+      $in: accountIds
+    }
+  }).toArray();
+
+  if (!accounts) {
+    throw new ReactionError("not-found", "No accounts matching the provided IDs were found");
+  }
+
+  if (accounts.length !== accountIds.length) {
+    throw new ReactionError("not-found", `Could not find ${accountIds.length - accounts.length} of ${accountIds.length} groups provided`);
+  }
+
+  await Accounts.updateMany({
+    _id: {
+      $in: accountIds
+    }
+  }, {
+    $set: {
+      groups: groupIds
+    }
+  });
+
+  const updatedAccounts = await Accounts.find({
+    _id: {
+      $in: accountIds
+    }
+  }).toArray()
+
+  for (let updatedAccount of updatedAccounts) {
+    await appEvents.emit("afterAccountUpdate", {
+      account: updatedAccount,
+      updatedBy: userId,
+      updatedFields: ["groups"]
+    });
+  }
+
+  // Return the accounts that were updated
+  return updatedAccounts;
+}

--- a/src/resolvers/Mutation/index.js
+++ b/src/resolvers/Mutation/index.js
@@ -12,6 +12,7 @@ import setAccountDefaultEmail from "./setAccountDefaultEmail.js";
 import updateAccount from "./updateAccount.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import updateAccountGroup from "./updateAccountGroup.js";
+import updateGroupsForAccounts from "./updateGroupsForAccounts.js";
 
 export default {
   addAccountAddressBookEntry,
@@ -27,5 +28,6 @@ export default {
   setAccountDefaultEmail,
   updateAccount,
   updateAccountAddressBookEntry,
-  updateAccountGroup
+  updateAccountGroup,
+  updateGroupsForAccounts
 };

--- a/src/resolvers/Mutation/updateGroupsForAccounts.js
+++ b/src/resolvers/Mutation/updateGroupsForAccounts.js
@@ -1,0 +1,31 @@
+import { decodeAccountOpaqueId, decodeGroupOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Mutation/updateGroupsForAccounts
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the updateGroupsForAccounts GraphQL mutation
+ * @param {Object} parentResult - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {Array|String} args.input.accountIds - The account IDs
+ * @param {Array|String} args.input.groupIds - The group IDs to assign to the accounts
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Object} UpdateGroupsForAccountsPayload
+ */
+export default async function updateGroupsForAccounts(parentResult, { input }, context) {
+  const { accountIds: opaqueAccountIds, groupIds: opaqueGroupIds, clientMutationId = null } = input;
+
+  const accountIds = opaqueAccountIds.map((id) => decodeAccountOpaqueId(id));
+  const groupIds = opaqueGroupIds.map((id) => decodeGroupOpaqueId(id));
+
+  const accounts = await context.mutations.updateGroupsForAccounts(context, {
+    accountIds,
+    groupIds
+  });
+
+  return {
+    accounts,
+    clientMutationId
+  };
+}

--- a/src/resolvers/Mutation/updateGroupsForAccounts.test.js
+++ b/src/resolvers/Mutation/updateGroupsForAccounts.test.js
@@ -1,0 +1,40 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import { encodeAccountOpaqueId, encodeGroupOpaqueId } from "../../xforms/id.js";
+import updateGroupsForAccounts from "./updateGroupsForAccounts.js";
+
+mockContext.mutations.updateGroupsForAccounts = jest.fn().mockName("mutations.updateGroupsForAccounts");
+
+test("correctly passes through to internal mutation function", async () => {
+  const accountIds = [encodeAccountOpaqueId("account1"), encodeAccountOpaqueId("account2")];
+  const groupIds = [encodeGroupOpaqueId("g1"), encodeGroupOpaqueId("g2"), encodeGroupOpaqueId("g3")];
+  const fakeResult = [
+    {
+      _id: "account1",
+      groups: ["g1", "g2", "g3"]
+    },
+    {
+      _id: "account2",
+      groups: ["g1", "g2", "g3"]
+    }
+  ];
+
+  mockContext.mutations.updateGroupsForAccounts.mockReturnValueOnce(Promise.resolve(fakeResult));
+
+  const result = await updateGroupsForAccounts(null, {
+    input: {
+      accountIds,
+      groupIds,
+      clientMutationId: "clientMutationId"
+    }
+  }, mockContext);
+
+  expect(mockContext.mutations.updateGroupsForAccounts).toHaveBeenCalledWith(mockContext, {
+    accountIds: ["account1", "account2"],
+    groupIds: ["g1", "g2", "g3"]
+  });
+
+  expect(result).toEqual({
+    accounts: fakeResult,
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -371,7 +371,7 @@ type UpdateGroupsForAccountsPayload {
   clientMutationId: String
 
   "The accounts that were modified"
-  accounts: [Account]
+  accounts: [Account]!
 }
 
 extend type Mutation {

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -409,6 +409,12 @@ extend type Mutation {
     "Mutation input"
     input: UpdateAccountInput!
   ): UpdateAccountPayload
+
+  "Bulk-update groups for accounts"
+  updateGroupsForAccounts(
+    "Mutation input"
+    input: UpdateGroupsForAccountsInput!
+  ): UpdateGroupsForAccountsPayload
 }
 
 extend type Query {

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -166,6 +166,17 @@ input SetAccountDefaultEmailInput {
   email: Email!
 }
 
+input UpdateGroupsForAccountsInput {
+  "The account IDs"
+  accountIds: [ID]!
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The group IDs"
+  groupIds: [ID]!
+}
+
 "Represents a single user account"
 type Account implements Node {
   "The account ID"
@@ -353,6 +364,14 @@ type UpdateAccountPayload {
 
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String
+}
+
+type UpdateGroupsForAccountsPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "The accounts that were modified"
+  accounts: [Account]
 }
 
 extend type Mutation {

--- a/src/schemas/group.graphql
+++ b/src/schemas/group.graphql
@@ -100,17 +100,6 @@ input RemoveAccountFromGroupInput {
   groupId: ID!
 }
 
-input UpdateGroupsForAccountsInput {
-  "The account IDs"
-  accountIds: [ID]!
-
-  "An optional string identifying the mutation call, which will be returned in the response payload"
-  clientMutationId: String
-
-  "The group IDs"
-  groupIds: [ID]!
-}
-
 "Represents an account group"
 type Group implements Node {
   "The group ID"
@@ -216,14 +205,6 @@ type RemoveAccountGroupPayload {
 
   "The removed group"
   group: Group
-}
-
-type UpdateGroupsForAccountsPayload {
-  "The same string you sent with the mutation params, for matching mutation calls with their responses"
-  clientMutationId: String
-
-  "The accounts that were modified"
-  accounts: [Account]
 }
 
 extend type Shop {

--- a/src/schemas/group.graphql
+++ b/src/schemas/group.graphql
@@ -100,6 +100,17 @@ input RemoveAccountFromGroupInput {
   groupId: ID!
 }
 
+input UpdateGroupsForAccountsInput {
+  "The account IDs"
+  accountIds: [ID]!
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The group IDs"
+  groupIds: [ID]!
+}
+
 "Represents an account group"
 type Group implements Node {
   "The group ID"
@@ -205,6 +216,14 @@ type RemoveAccountGroupPayload {
 
   "The removed group"
   group: Group
+}
+
+type UpdateGroupsForAccountsPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "The accounts that were modified"
+  accounts: [Account]
 }
 
 extend type Shop {


### PR DESCRIPTION
Resolves #7 
Impact: **major**
Type: **feature**

## Issue
There is currently no way to bulk-edit the `groups` field for multiple accounts at the same time. I need this as I'm building a new Accounts page in `reaction-admin`, which is using `DataTable`s with bulk-edit capabilities to display accounts.

## Solution
Write a mutation that takes `groupIds` and `accountIds` variables. Its purpose should be to assign the `groupIds` to all the accounts referred to in `accountIds`.

## Testing
1. Call `updateGroupsForAccounts` to assign multiple `groupIds` to multiple accounts at the same time.
2. See that these groups were assigned to all of these accounts.
3. Test with multiple groups on a single account.
4. See that these groups were assigned to the account as well.