### PR TITLE
Add `customers` query

### DIFF
--- a/src/queries/accounts.js
+++ b/src/queries/accounts.js
@@ -6,18 +6,33 @@
  * @param {Object} context - an object containing the per-request state
  * @param {String} input - input for query
  * @param {String} [input.groupIds] - Array of group IDs to limit the results
+ * @param {String} [input.notInAnyGroups] - Return accounts that aren't part of any groups
  * @returns {Promise} Mongo cursor
  */
 export default async function accounts(context, input) {
   const { collections } = context;
   const { Accounts } = collections;
-  const { groupIds } = input;
+  const { groupIds, notInAnyGroups } = input;
 
   await context.validatePermissions("reaction:legacy:accounts", "read");
 
   const selector = {};
-  if (groupIds) {
+  if (groupIds && notInAnyGroups) {
+    selector.$or = [
+      {
+        groups: {
+          $in: groupIds
+        }
+      }, {
+        groups: {
+          $in: [null, []]
+        }
+      }
+    ];
+  } else if (groupIds) {
     selector.groups = { $in: groupIds };
+  } else if (notInAnyGroups) {
+    selector.groups = { $in: [null, []] };
   }
 
   return Accounts.find(selector);

--- a/src/queries/customers.js
+++ b/src/queries/customers.js
@@ -1,0 +1,18 @@
+/**
+ * @name customers
+ * @method
+ * @memberof Accounts/NoMeteorQueries
+ * @summary Returns accounts optionally filtered by group IDs
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Promise} Mongo cursor
+ */
+export default async function customers(context) {
+  const { collections } = context;
+  const { Accounts } = collections;
+
+  await context.validatePermissions("reaction:legacy:accounts", "read");
+
+  return Accounts.find({
+    groups: []
+  });
+}

--- a/src/queries/customers.js
+++ b/src/queries/customers.js
@@ -13,6 +13,6 @@ export default async function customers(context) {
   await context.validatePermissions("reaction:legacy:accounts", "read");
 
   return Accounts.find({
-    groups: []
+    groups: { $in: [null, []] }
   });
 }

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,4 +1,5 @@
 import accounts from "./accounts.js";
+import customers from "./customers.js";
 import group from "./group.js";
 import groups from "./groups.js";
 import groupsByAccount from "./groupsByAccount.js";
@@ -6,6 +7,7 @@ import userAccount from "./userAccount.js";
 
 export default {
   accounts,
+  customers,
   group,
   groups,
   groupsByAccount,

--- a/src/resolvers/Query/accounts.js
+++ b/src/resolvers/Query/accounts.js
@@ -10,19 +10,20 @@ import { decodeGroupOpaqueId } from "../../xforms/id.js";
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client
  * @param {String} [args.groupIds] - Array of group IDs
+ * @param {Boolean} [args.notInAnyGroups] - Return accounts that aren't part of any groups
  * @param {Object} context - an object containing the per-request state
  * @param {Object} info Info about the GraphQL request
  * @returns {Promise<Object>} Promise containing queried accounts
  */
 export default async function accounts(_, args, context, info) {
-  const { groupIds: opaqueGroupIds, ...connectionArgs } = args;
+  const { groupIds: opaqueGroupIds, notInAnyGroups, ...connectionArgs } = args;
 
   let groupIds;
   if (opaqueGroupIds) {
     groupIds = opaqueGroupIds.map((opaqueGroupId) => decodeGroupOpaqueId(opaqueGroupId));
   }
 
-  const query = await context.queries.accounts(context, { groupIds });
+  const query = await context.queries.accounts(context, { groupIds, notInAnyGroups });
 
   return getPaginatedResponse(query, connectionArgs, {
     includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),

--- a/src/resolvers/Query/customers.js
+++ b/src/resolvers/Query/customers.js
@@ -1,0 +1,23 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+
+/**
+ * @name Query/customers
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary query the Accounts collection and return a list of customer accounts
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object>} Promise containing queried accounts
+ */
+export default async function customers(_, args, context, info) {
+  const query = await context.queries.customers(context);
+
+  return getPaginatedResponse(query, args, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/resolvers/Query/index.js
+++ b/src/resolvers/Query/index.js
@@ -1,5 +1,6 @@
 import account from "./account.js";
 import accounts from "./accounts.js";
+import customers from "./customers.js";
 import group from "./group.js";
 import groups from "./groups.js";
 import viewer from "./viewer.js";
@@ -7,6 +8,7 @@ import viewer from "./viewer.js";
 export default {
   account,
   accounts,
+  customers,
   group,
   groups,
   viewer

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -423,6 +423,9 @@ extend type Query {
     "Return only accounts in any of these groups"
     groupIds: [ID],
 
+    "Return accounts that aren't in any groups"
+    notInAnyGroups: Boolean,
+
     "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
     after: ConnectionCursor,
 

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -445,6 +445,30 @@ extend type Query {
     sortBy: AccountSortByField = createdAt
   ): AccountConnection!
 
+  "Returns customer accounts"
+  customers(
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor,
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor,
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt,
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
+    "Return results sorted in this order"
+    sortOrder: SortOrder = asc,
+
+    "By default, groups are sorted by when they were created, oldest first. Set this to sort by one of the other allowed fields"
+    sortBy: AccountSortByField = createdAt
+  ): AccountConnection!
+
   "Returns the account for the authenticated user"
   viewer: Account
 }


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #12 
Impact: **major**
Type: **feature**

## Issue
There was no way to get all the customer accounts with a GraphQL query.

## Solution
Create a `customers` query which returns all the customers as paginated data.

## Breaking changes
None.


## Testing
1. Create customer accounts through a storefront.
2. Query `customers` with an admin's `Authorization` token.
3. See all of the customer accounts being returned.