### PR TITLE
Add offset for Shop groups and qroups query

### DIFF
--- a/src/schemas/group.graphql
+++ b/src/schemas/group.graphql
@@ -222,6 +222,9 @@ extend type Shop {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,
 
@@ -244,6 +247,9 @@ extend type Account {
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
 
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,
@@ -308,6 +314,9 @@ extend type Query {
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
 
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Issue https://github.com/reactioncommerce/reaction/issues/6252
Impact: **minor**
Type: **bugfix**

## Issue
Missing offset params for pagination for 'Account Groups`, `Shop Groups` and `Groups` queries
