### PR TITLE
Add missing selectRoles i18n label

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -37,7 +37,8 @@
             "name": "Name",
             "slug": "Slug",
             "description": "Description",
-            "saveFailed": "Failed to create/update group."
+            "saveFailed": "Failed to create/update group.",
+            "selectRoles": "Roles"
           },
           "inviteStaffMemberDialog": {
             "title": "Invite Staff Member",


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Impact: **minor**
Type: **bugfix**

## Issue
The `admin.groupCards.createOrUpdateGroupDialog.selectRoles` i18n label is missing.

## Solution
Add the label.

## Breaking changes
None.

## Testing
None.