### PR TITLE
Check if groupIds not empty before calling updateGroupsForAccounts

### DIFF
--- a/src/mutations/createAccount.js
+++ b/src/mutations/createAccount.js
@@ -111,10 +111,12 @@ export default async function createAccount(context, input) {
 
   await Accounts.insertOne(account);
 
-  await context.mutations.updateGroupsForAccounts(context.getInternalContext(), {
-    accountIds: [account._id],
-    groupIds: Array.from(groups)
-  });
+  if (groups.size > 0) {
+    await context.mutations.updateGroupsForAccounts(context.getInternalContext(), {
+      accountIds: [account._id],
+      groupIds: Array.from(groups)
+    });
+  }
 
   // Delete any invites that are now finished
   if (invites) {

--- a/src/mutations/updateGroupsForAccounts.js
+++ b/src/mutations/updateGroupsForAccounts.js
@@ -42,7 +42,7 @@ export default async function updateGroupsForAccounts(context, input) {
     }
   }).toArray();
 
-  if (groupsToAssignAccountsTo.length === 0) {
+  if (groupsToAssignAccountsTo.length === 0 && groupIds.length > 0) {
     throw new ReactionError("not-found", "No groups matching the provided IDs were found");
   }
 


### PR DESCRIPTION
Resolves #27
Impact: **major**
Type: **bugfix**

## Issue
`updateGroupsForAccounts` can throw an error if no groups are provided, and in `createAccount`, the mutation is called regardless of whether there are groups to add or not.

## Solution
Check if there are groups to add to the account in `createAccount` before calling `updateGroupsForAccounts`. This will prevent the mutation from being called when it isn't needed. Also check if `groupIds` were passed before throwing an error about groups not being found.

## Breaking changes
None.

## Testing
1. Create a customer account, expect no errors.
2. Create an admin account from an invitation, expect no errors. 
3. Check that the relevant groups were added to the admin account in the `Accounts` MongoDB collection.