### PR TITLE
fix: add offset to the addressBook graphql schema

### DIFF
--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -194,7 +194,10 @@ type Account implements Node {
     first: ConnectionLimitInt,
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
-    last: ConnectionLimitInt
+    last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int
   ): AddressConnection
 
   "A list of shops this user can administer with the admin UI"


### PR DESCRIPTION
The pagination util function supports `offset` automatically, but the `offset` field needs to be added to the GraphQL schema params for each query for it to work.

This PR adds `offset` to the `addressBook` graphQL schema.

Master issue: https://github.com/reactioncommerce/reaction/issues/6252

Signed-off-by: Maria Paktiti <maria.paktiti@gmail.com>