### PR TITLE
Update spanish translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -35,7 +35,7 @@
           "createOrUpdateGroupDialog": {
             "title": "Crear/Actualizar grupo",
             "name": "Nombre",
-            "slug": "Slug",
+            "slug": "Identificador",
             "description": "Descripción",
             "saveFailed": "No se pudo crear/actualizar el grupo.",
             "selectRoles": "Roles"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -41,17 +41,17 @@
             "selectRoles": "Roles"
           },
           "inviteStaffMemberDialog": {
-            "title": "Invite Staff Member",
-            "name": "Full Name",
-            "email": "E-mail Address",
-            "selectGroups": "Groups",
-            "saveFailed": "Failed to invite staff member."
+            "title": "Invitar empleado",
+            "name": "Nombre Completo",
+            "email": "Dirección de correo electrónico",
+            "selectGroups": "Grupos",
+            "saveFailed": "No se pudo invitar a un miembro del personal."
           }
         },
         "dashboard": {
           "accountsLabel": "Cuentas",
           "accountsTitle": "Cuentas",
-          "accountsDescription": "Configuraciones De La Cuenta",
+          "accountsDescription": "Configuraciones de la cuenta",
           "manageGroups": "Administrar grupos"
         },
         "settings": {
@@ -63,11 +63,11 @@
           "updateGroupSuccess": "Grupo actualizado con éxito",
           "createGroupError": "Error al crear grupo",
           "updateGroupError": "Error al actualizar el grupo",
-          "changeShopOwnerWarn": "Estás a punto de cambiar el dueño de la tienda. El propietario actual será reemplazado",
+          "changeShopOwnerWarn": "Estás a punto de cambiar el propietario de la tienda. El propietario actual será reemplazado",
           "removeUserWarn": "Está a punto de eliminar un usuario de un grupo. El usuario perderá los permisos asociados",
           "accountsSettingsLabel": "Cuentas",
           "accountsSettingsTitle": "Cuentas",
-          "accountsSettingsDescription": "Configuraciones De La Cuenta"
+          "accountsSettingsDescription": "Configuraciones de la Cuenta"
         },
         "groupsInvite": {
           "name": "John Smith",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -4,10 +4,55 @@
   "translation": {
     "reaction-accounts": {
       "admin": {
+        "accounts": {
+          "tabs": {
+            "staff": "Empleados",
+            "customers": "Clientes",
+            "invites": "Invitaciones"
+          },
+          "accountsLabel": "Cuentas",
+          "createGroup": "Crea un grupo",
+          "inviteStaffMember": "Invitar empleado"
+        },
+        "accountsTable": {
+          "header": {
+            "email": "Dirección de correo electrónico",
+            "name": "Nombre"
+          },
+          "bulkActions": {
+            "addRemoveGroupsFromAccount": "Agregar/Quitar grupos de la cuenta"
+          }
+        },
+        "invitationsTable": {
+          "header": {
+            "email": "Dirección de correo electrónico",
+            "invitedBy": "Invitado por",
+            "shop": "Tienda",
+            "groups": "Grupos"
+          }
+        },
+        "groupCards": {
+          "createOrUpdateGroupDialog": {
+            "title": "Crear/Actualizar grupo",
+            "name": "Nombre",
+            "slug": "Slug",
+            "description": "Descripción",
+            "saveFailed": "No se pudo crear/actualizar el grupo.",
+            "selectRoles": "Roles"
+          },
+          "inviteStaffMemberDialog": {
+            "title": "Invite Staff Member",
+            "name": "Full Name",
+            "email": "E-mail Address",
+            "selectGroups": "Groups",
+            "saveFailed": "Failed to invite staff member."
+          }
+        },
         "dashboard": {
           "accountsLabel": "Cuentas",
           "accountsTitle": "Cuentas",
-          "accountsDescription": "Configuraciones De La Cuenta"
+          "accountsDescription": "Configuraciones De La Cuenta",
+          "manageGroups": "Administrar grupos"
         },
         "settings": {
           "continue": "Continuar",


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

## Issue
The new UI for the accounts plugin uses new keys that are no updated on the i18n file for Spanish

## Solution
Add missing keys in es.json

## Breaking changes
None

