### PR TITLE
Add migration for invitations/read role

### DIFF
--- a/migrations/3.js
+++ b/migrations/3.js
@@ -1,0 +1,52 @@
+const affectedGlobalGroups = [
+  "system-manager"
+];
+
+const newGlobalPermissions = [
+  "reaction:legacy:invitations/read"
+];
+
+/**
+ * @summary migrates the database down one version
+ * @param {Object} context Migration context
+ * @param {Object} context.db MongoDB `Db` instance
+ * @param {Function} context.progress A function to report progress, takes percent
+ *   number as argument.
+ * @return {undefined}
+ */
+async function down({ db, progress }) {
+  progress(0);
+
+  await db.collection("Groups").updateMany({
+    slug: { $in: affectedGlobalGroups }
+  }, {
+    $pullAll: { permissions: newGlobalPermissions }
+  });
+
+  progress(100);
+}
+
+/**
+ * @summary Performs migration up from previous data version
+ * @param {Object} context Migration context
+ * @param {Object} context.db MongoDB `Db` instance
+ * @param {Function} context.progress A function to report progress, takes percent
+ *   number as argument.
+ * @return {undefined}
+ */
+async function up({ db, progress }) {
+  progress(0);
+
+  await db.collection("Groups").updateMany({
+    slug: { $in: affectedGlobalGroups }
+  }, {
+    $addToSet: { permissions: { $each: newGlobalPermissions } }
+  });
+
+  progress(100);
+}
+
+export default {
+  down,
+  up
+};

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -1,12 +1,14 @@
 import { migrationsNamespace } from "./migrationsNamespace.js";
 import migration2 from "./2.js";
+import migration3 from "./3.js";
 
 export default {
   tracks: [
     {
       namespace: migrationsNamespace,
       migrations: {
-        2: migration2
+        2: migration2,
+        3: migration3
       }
     }
   ]

--- a/src/preStartup/checkDatabaseVersion.js
+++ b/src/preStartup/checkDatabaseVersion.js
@@ -1,7 +1,7 @@
 import doesDatabaseVersionMatch from "@reactioncommerce/db-version-check";
 import { migrationsNamespace } from "../../migrations/migrationsNamespace.js";
 
-const expectedVersion = 2;
+const expectedVersion = 3;
 
 /**
  * @summary Called before startup to check whether the database is at the right version

--- a/src/resolvers/Account/adminUIShops.js
+++ b/src/resolvers/Account/adminUIShops.js
@@ -9,6 +9,10 @@
  * @returns {Promise<Object>} A connection object
  */
 export default async function adminUIShops(account, args, context) {
+  if (!account || !account.adminUIShopIds || account.adminUIShopIds.length === 0) {
+    return [];
+  }
+
   const shopCursor = await context.queries.shops(context, { shopIds: account.adminUIShopIds });
 
   return shopCursor.toArray();

--- a/src/schemas/inviteShopMember.graphql
+++ b/src/schemas/inviteShopMember.graphql
@@ -74,8 +74,8 @@ type Invitation implements Node {
   "The groups this person was invited to"
   groups: [Group]!
 
-  "The shop this person was invited to"
-  shop: Shop!
+  "The shop this person was invited to. Optional because we can also invite merchants to create their own shops."
+  shop: Shop
 
   "The admin who invited this person"
   invitedBy: Account


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Impact: **major**
Type: **bugfix|chore**

## Issue
I realized that the `reaction:legacy:invitations/read` role is checked when querying `invitations` for all shops, but this role was never added to any groups with a mutations. Hence, querying `invitations` for all shops will fail with an `Access Denied` error.

## Solution
Add the `reaction:legacy:invitations/read` role to the `system-manager` group with a migration.

## Breaking changes
None.

## Testing
1. Run migration `3` on this plugin.
2. Query `invitations` with `shopIds: []`.
3. Get results back.