### PR TITLE
fix: use userId directly when emitting events

### DIFF
--- a/src/mutations/removeAccountGroup.js
+++ b/src/mutations/removeAccountGroup.js
@@ -17,7 +17,7 @@ import removeAccountsFromGroup from "../util/removeAccountsFromGroup.js";
  */
 export default async function removeAccountGroup(context, input) {
   const { groupId, shopId } = input;
-  const { appEvents, user } = context;
+  const { appEvents, userId } = context;
   const { Groups } = context.collections;
 
   await context.validatePermissions(`reaction:legacy:groups:${groupId}`, "remove", { shopId });
@@ -51,7 +51,7 @@ export default async function removeAccountGroup(context, input) {
 
   await appEvents.emit("afterAccountGroupDelete", {
     group: deletedGroup,
-    updatedBy: user._id
+    updatedBy: userId
   });
 
   return deletedGroup;

--- a/src/mutations/updateAccountGroup.js
+++ b/src/mutations/updateAccountGroup.js
@@ -22,7 +22,7 @@ export default async function updateAccountGroup(context, input) {
     appEvents,
     collections: { Groups },
     simpleSchemas: { Group },
-    user
+    userId
   } = context;
 
   // we are limiting group method actions to only users within the account managers role
@@ -61,7 +61,7 @@ export default async function updateAccountGroup(context, input) {
 
   await appEvents.emit("afterAccountGroupUpdate", {
     group: updatedGroup,
-    updatedBy: user._id,
+    updatedBy: userId,
     updatedFields: Object.keys(modifier.$set)
   });
 


### PR DESCRIPTION
Signed-off-by: Matias Zuniga <matias.nicolas.zc@gmail.com>

Resolves #33
Impact: **minor**
Type: **bugfix**

## Issue
removeAccountGroup and updateAccountGroup mutations are trying to get `_id ` from the user object, that can be null.

## Solution
As suggested on the issue, use userId directly.