### PR TITLE
Shift pre-build dependency token to pre-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,6 @@ jobs:
     docker:
       - image: node:12.14.1
 
-    dependencies:
-      pre:
-        - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-
     steps:
       - checkout
 
@@ -21,6 +17,10 @@ jobs:
   deploy:
     docker:
       - image: node:12.14.1
+
+    dependencies:
+      pre:
+        - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
     steps:
       - checkout


### PR DESCRIPTION
Running into issues where forked PRs are not built. 
We'd like forked PRs to build, but not deploy. 
This might resolve this issue by moving the secrets out of the build step.

Resolves: unreported issue
Impact: **minor**
Type: **bugfix**