### PR TITLE
fix: permit building forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,6 @@ jobs:
     docker:
       - image: node:12.14.1
 
-    dependencies:
-      pre:
-        - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-
     steps:
       - checkout
 
@@ -21,6 +17,10 @@ jobs:
   deploy:
     docker:
       - image: node:12.14.1
+
+    dependencies:
+      pre:
+        - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
     steps:
       - checkout


### PR DESCRIPTION
Updates CircleCI config to move the NPM token into the
deploy step and out of the build step. The token being
in the build step was causing forked PRs to be blocked
from being built.

Signed-off-by: Spencer Norman <spencer.norman@mailchimp.com>