### PR TITLE
Fix 2 create acc not working

### DIFF
--- a/src/mutations/createAccount.js
+++ b/src/mutations/createAccount.js
@@ -32,8 +32,7 @@ export default async function createAccount(context, input) {
     name = null,
     profile,
     shopId = null,
-    userId,
-    clientMutationId = null,
+    userId
   } = input;
 
   await context.validatePermissions("reaction:legacy:accounts", "create", { shopId });
@@ -124,8 +123,5 @@ export default async function createAccount(context, input) {
     createdBy: authUserId
   });
 
-  return {
-    account,
-    clientMutationId
-  };
+  return account;
 }

--- a/src/mutations/createAccount.js
+++ b/src/mutations/createAccount.js
@@ -1,4 +1,3 @@
-import SimpleSchema from "simpl-schema";
 import Logger from "@reactioncommerce/logger";
 import ensureAccountsManagerGroup from "../util/ensureAccountsManagerGroup.js";
 import ensureSystemManagerGroup from "../util/ensureSystemManagerGroup.js";
@@ -17,7 +16,7 @@ import sendWelcomeEmail from "../util/sendWelcomeEmail.js";
  * @param {String} input.userId - userId account was created from
  * @return {Promise<Object>} with boolean of found new account === true || false
  */
-export default async function createAccount(context, input) { 
+export default async function createAccount(context, input) {
   const {
     appEvents,
     collections: { Accounts, AccountInvites },

--- a/src/mutations/createAccount.js
+++ b/src/mutations/createAccount.js
@@ -4,28 +4,6 @@ import ensureAccountsManagerGroup from "../util/ensureAccountsManagerGroup.js";
 import ensureSystemManagerGroup from "../util/ensureSystemManagerGroup.js";
 import sendWelcomeEmail from "../util/sendWelcomeEmail.js";
 
-const inputSchema = new SimpleSchema({
-  "emails": Array,
-  "emails.$": {
-    type: Object,
-    blackbox: true
-  },
-  "name": {
-    type: String,
-    optional: true
-  },
-  "profile": {
-    type: Object,
-    blackbox: true,
-    optional: true
-  },
-  "shopId": {
-    type: String,
-    optional: true
-  },
-  "userId": String
-});
-
 /**
  * @name accounts/createAccount
  * @memberof Mutations/Accounts
@@ -39,9 +17,7 @@ const inputSchema = new SimpleSchema({
  * @param {String} input.userId - userId account was created from
  * @return {Promise<Object>} with boolean of found new account === true || false
  */
-export default async function createAccount(context, input) {
-  inputSchema.validate(input);
-
+export default async function createAccount(context, input) { 
   const {
     appEvents,
     collections: { Accounts, AccountInvites },
@@ -56,7 +32,8 @@ export default async function createAccount(context, input) {
     name = null,
     profile,
     shopId = null,
-    userId
+    userId,
+    clientMutationId = null,
   } = input;
 
   await context.validatePermissions("reaction:legacy:accounts", "create", { shopId });
@@ -147,5 +124,8 @@ export default async function createAccount(context, input) {
     createdBy: authUserId
   });
 
-  return account;
+  return {
+    account,
+    clientMutationId
+  };
 }

--- a/src/resolvers/Mutation/createAccount.js
+++ b/src/resolvers/Mutation/createAccount.js
@@ -13,10 +13,15 @@ import { decodeShopOpaqueId } from "../../xforms/id.js";
  * @returns {Object} - `object.status` of 200 on success or Error object on failure
  */
 export default async function createAccount(_, { input }, context) {
-  const { shopId } = input;
+  const { shopId, clientMutationId } = input;
   const decodedShopId = decodeShopOpaqueId(shopId);
 
   const transformedInput = { ...input, shopId: decodedShopId };
 
-  return context.mutations.createAccount(context, transformedInput);
+  const account = context.mutations.createAccount(context, transformedInput);
+
+  return {
+    account,
+    clientMutationId
+  }
 }

--- a/src/resolvers/Mutation/createAccount.js
+++ b/src/resolvers/Mutation/createAccount.js
@@ -1,0 +1,22 @@
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name group/createAccount
+ * @method
+ * @memberof Group/GraphQL
+ * @summary A resolver creates a new account for an existing user 
+ * @param {object} _ - Not used
+ * @param {object} input - The input supplied from GraphQL
+ * @param {String} input.shopId - id of the shop in which the account is to be created
+ * @param {String} input.userId - id of the user for who the account is to be created
+ * @param {object} context - The GraphQL context
+ * @returns {Object} - `object.status` of 200 on success or Error object on failure
+ */
+export default async function createAccount(_, { input }, context) {
+  const { shopId } = input;
+  const decodedShopId = decodeShopOpaqueId(shopId);
+
+  const transformedInput = { ...input, shopId: decodedShopId };
+
+  return context.mutations.createAccount(context, transformedInput);
+}

--- a/src/resolvers/Mutation/createAccount.js
+++ b/src/resolvers/Mutation/createAccount.js
@@ -4,7 +4,7 @@ import { decodeShopOpaqueId } from "../../xforms/id.js";
  * @name group/createAccount
  * @method
  * @memberof Group/GraphQL
- * @summary A resolver creates a new account for an existing user 
+ * @summary A resolver creates a new account for an existing user
  * @param {object} _ - Not used
  * @param {object} input - The input supplied from GraphQL
  * @param {String} input.shopId - id of the shop in which the account is to be created
@@ -23,5 +23,5 @@ export default async function createAccount(_, { input }, context) {
   return {
     account,
     clientMutationId
-  }
+  };
 }

--- a/src/resolvers/Mutation/createAccount.test.js
+++ b/src/resolvers/Mutation/createAccount.test.js
@@ -1,42 +1,42 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
-import createAccount from "./createAccount.js";
 import { encodeShopOpaqueId } from "../../xforms/id.js";
+import createAccount from "./createAccount.js";
 
 mockContext.mutations.createAccount = jest.fn().mockName("mutations.createAccount");
 
-test("create a new account", async() => {
-    const emails = {
+test("create a new account", async () => {
+  const emails = {
+    address: "mock-email",
+    verified: false
+  };
+  const encodedShopId = encodeShopOpaqueId("mock-shop-id");
+  const input = {
+    userId: "mock-user-id",
+    shopId: encodedShopId,
+    name: "mock-name",
+    emails,
+    clientMutationId: "mock-client-mutation-id"
+  };
+  const mockReturn = {
+    userId: "mock-user-id",
+    shopId: encodedShopId,
+    name: "mock-name",
+    emails
+  };
+
+  mockContext.mutations.createAccount.mockReturnValueOnce(mockReturn);
+
+  const result = await createAccount(null, { input }, mockContext);
+  await expect(await result).toEqual({
+    account: {
+      userId: "mock-user-id",
+      shopId: encodedShopId,
+      name: "mock-name",
+      emails: {
         address: "mock-email",
-        verified: false,
-    }
-    const encodedShopId = encodeShopOpaqueId("mock-shop-id")
-    const input = {
-        userId: "mock-user-id",
-        shopId: encodedShopId,
-        name: "mock-name",
-        emails,
-        clientMutationId: "mock-client-mutation-id"
-    };
-    const mockReturn = {
-        userId: "mock-user-id",
-        shopId: encodedShopId,
-        name: "mock-name",
-        emails,
-    };
-
-    mockContext.mutations.createAccount.mockReturnValueOnce(mockReturn);
-
-    const result = await createAccount(null, { input }, mockContext);
-    await expect(await result).toEqual({
-        account: {
-            userId: 'mock-user-id',
-            shopId: encodedShopId,
-            name: 'mock-name',
-            emails: {
-                "address": "mock-email",
-                "verified": false,
-            }
-        },
-        clientMutationId: "mock-client-mutation-id"
-      });
+        verified: false
+      }
+    },
+    clientMutationId: "mock-client-mutation-id"
+  });
 });

--- a/src/resolvers/Mutation/createAccount.test.js
+++ b/src/resolvers/Mutation/createAccount.test.js
@@ -1,0 +1,42 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import createAccount from "./createAccount.js";
+import { encodeShopOpaqueId } from "../../xforms/id.js";
+
+mockContext.mutations.createAccount = jest.fn().mockName("mutations.createAccount");
+
+test("create a new account", async() => {
+    const emails = {
+        address: "mock-email",
+        verified: false,
+    }
+    const encodedShopId = encodeShopOpaqueId("mock-shop-id")
+    const input = {
+        userId: "mock-user-id",
+        shopId: encodedShopId,
+        name: "mock-name",
+        emails,
+        clientMutationId: "mock-client-mutation-id"
+    };
+    const mockReturn = {
+        userId: "mock-user-id",
+        shopId: encodedShopId,
+        name: "mock-name",
+        emails,
+    };
+
+    mockContext.mutations.createAccount.mockReturnValueOnce(mockReturn);
+
+    const result = await createAccount(null, { input }, mockContext);
+    await expect(await result).toEqual({
+        account: {
+            userId: 'mock-user-id',
+            shopId: encodedShopId,
+            name: 'mock-name',
+            emails: {
+                "address": "mock-email",
+                "verified": false,
+            }
+        },
+        clientMutationId: "mock-client-mutation-id"
+      });
+});

--- a/src/resolvers/Mutation/index.js
+++ b/src/resolvers/Mutation/index.js
@@ -1,6 +1,7 @@
 import addAccountAddressBookEntry from "./addAccountAddressBookEntry.js";
 import addAccountEmailRecord from "./addAccountEmailRecord.js";
 import addAccountToGroup from "./addAccountToGroup.js";
+import createAccount from "./createAccount.js";
 import createAccountGroup from "./createAccountGroup.js";
 import grantAdminUIAccess from "./grantAdminUIAccess.js";
 import inviteShopMember from "./inviteShopMember.js";
@@ -21,6 +22,7 @@ export default {
   addAccountAddressBookEntry,
   addAccountEmailRecord,
   addAccountToGroup,
+  createAccount,
   createAccountGroup,
   grantAdminUIAccess,
   inviteShopMember,

--- a/src/schemas/account.graphql
+++ b/src/schemas/account.graphql
@@ -53,6 +53,9 @@ input CreateAccountInput {
 
   "Username"
   username: String
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
 }
 
 "Describes changes that should be applied to one of the addresses for an account"
@@ -254,6 +257,50 @@ type Account implements Node {
   username: String
 }
 
+"Represents a single user partial account"
+type BasicAccount implements Node {
+  "The account ID"
+  _id: ID!
+
+  "Flag to indicate if the account accepts marketing emails"
+  acceptsMarketing: Boolean
+
+  "Email record associated with the account"
+  emails: [EmailRecord]
+
+  "List of group Ids to which the account belongs"
+  groups: [String]
+
+  "The full name of the person this account represents, if known"
+  name: String
+
+  "List of shipping/billing addresses"
+  profile: [Profile]
+
+  "ID of shop"
+  shopId: String
+
+  "Account creation state"
+  state: String
+
+  "ID of user"
+  userId: String
+
+  "The date and time at which this account was created"
+  createdAt: DateTime
+
+  "The date and time at which this account was last updated"
+  updatedAt: DateTime
+
+  "List of shop Ids"
+  adminUIShopIds: [String]
+
+}
+
+type Profile {
+  addressBook: [Address]
+}
+
 """
 Wraps a list of `Accounts`, providing pagination cursors and information.
 
@@ -312,7 +359,7 @@ type AddAccountEmailRecordPayload {
 "The response from the `createAccount` mutation"
 type CreateAccountPayload {
   "The added account"
-  account: Account
+  account: BasicAccount
 
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String


### PR DESCRIPTION
Resolves #2 
Impact: **minor**
Type: **bugfix**

## Issue
When calling createAccount directly in GraphQL (or another interface), the account is not created as expected - null is returned, and no account is seen in the collection.

## Solution
Add resolver for createAccount mutation.
Correct the schema for the returning payload.

## Breaking changes
No breaking changes but good to keep an eye on the following.
- The createAccount method still returns the same account. So, this should not cause issues at other parts of the code that calls createAccount and uses the account object.
- In the schema `CreateAccountInput` now has an optional `clientMutationId` field. Since its optional it should not affect any custom create account implementations.


## Testing
Find shopId and userId
```
mutation{
  createAccount(input:{
    bio:"Test bio"
    emails:{
      address:"test@org.com"
      provides:"something"
      verified:false
    }
    shopId:"<shopId>"
    userId:"<userId>"
    name: "test name"
    username: "test username"
    
  })
  {
    account{
      name
      _id
      userId
      acceptsMarketing
      createdAt
      shopId
      state
      updatedAt
      userId
      emails{
        address
        provides
        verified
      }
      groups
      profile{
        addressBook{
          address1
        }
      }
      adminUIShopIds
    }
  }
}
```
1. Run the above query before pulling the changes. GraphQL playground will return `null` and the DB will not have a new entry for Accounts collection
2. Pull the changes and link the accounts plugin using `bin/package-link @reactioncommerce/api-plugin-accounts`.
3. Run the same query. You should see values in Playground and a new entry in the DB.
