### PR TITLE
chore: context not required in build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,7 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - build:
-          context: reaction-publish-semantic-release
+      - build
       - lint:
           requires:
             - build


### PR DESCRIPTION
Signed-off-by: Akarshit Wal <akarshitwal@gmail.com>

Impact: **minor**
Type: **chore**

## Issue
The CircleCI build is failing for all community PRs because the release context is being required in the build step.

## Solution
Removing the context that's not needed.

## Breaking changes
None

## Testing
The CircleCI test passing should be a good enough parameter to test.