### PR TITLE
Create shop for every account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@reactioncommerce/api-plugin-accounts",
+  "name": "@itleadopencommerce/api-plugin-accounts",
   "description": "Accounts plugin for the Reaction API",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "main": "index.js",
   "type": "module",
   "engines": {
     "node": ">=14.18.1"
   },
-  "homepage": "https://github.com/reactioncommerce/api-plugin-accounts",
-  "url": "https://github.com/reactioncommerce/api-plugin-accounts",
+  "homepage": "https://github.com/OlehObodin/api-plugin-accounts",
+  "url": "https://github.com/OlehObodin/api-plugin-accounts",
   "email": "hello-open-commerce@mailchimp.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/api-plugin-accounts.git"
+    "url": "git+https://github.com/OlehObodin/api-plugin-accounts.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -21,7 +21,7 @@
   },
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/api-plugin-accounts/issues"
+    "url": "https://github.com/OlehObodin/api-plugin-accounts/issues"
   },
   "sideEffects": false,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "homepage": "https://github.com/OlehObodin/api-plugin-accounts",
   "url": "https://github.com/OlehObodin/api-plugin-accounts",
-  "email": "hello-open-commerce@mailchimp.com",
+  "email": "dev@it-lead.eu",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OlehObodin/api-plugin-accounts.git"
   },
   "author": {
-    "name": "Reaction Commerce",
-    "email": "hello-open-commerce@mailchimp.com",
+    "name": "Reaction Commerce / Oleh Obodin",
+    "email": "dev@it-lead.eu",
     "url": "https://mailchimp.com/developer/open-commerce"
   },
   "license": "GPL-3.0",


### PR DESCRIPTION
Resolves #issueNumber
Impact: **breaking|critical|major|minor**
Type: **feature|bugfix|performance|test|style|refactor|docs|chore**

## Issue
Then registering more then one account there is no ability by default create shops


## Breaking changes
Rewritten logic for create account


## Testing
1. List the steps needed for testing your change in this section.
2. Assume that testers already know how to start the app, and do the basic setup tasks.
3. Be detailed enough that someone can work through it without being too granular.
